### PR TITLE
Filter invalid float values

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"time"
 )
@@ -40,6 +41,11 @@ func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
 }
 
 func (h *MackerelPlugin) printValue(w io.Writer, key string, value float64, now time.Time) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		log.Printf("Invalid value: key = %s, value = %f\n", key, value)
+		return
+	}
+
 	if value == float64(int(value)) {
 		fmt.Fprintf(w, "%s\t%d\t%d\n", key, int(value), now.Unix())
 	} else {


### PR DESCRIPTION
Agents try to send invalid plugin float values, so filter them.
```
2015/01/05 16:33:16 ERROR command Failed to post metrics value (will retry): json: unsupported value: +Inf
```
```
2015/01/06 13:35:31 ERROR command Failed to post metrics value (will retry): json: unsupported value: NaN
```

(I suppose that mackerel-agent should also check them for older plugins)