### PR TITLE
Better handling with reset and overflow

### DIFF
--- a/_example/memcached.go
+++ b/_example/memcached.go
@@ -4,14 +4,15 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	mp "github.com/mackerelio/go-mackerel-plugin"
 	"log"
 	"net"
 	"os"
-	"strconv"
 	"strings"
+
+	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
+// https://github.com/memcached/memcached/blob/master/doc/protocol.txt
 var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
 	"memcached.connections": mp.Graphs{
 		Label: "Memcached Connections",
@@ -24,41 +25,41 @@ var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
 		Label: "Memcached Command",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "cmd_get", Label: "Get", Diff: true},
-			mp.Metrics{Name: "cmd_set", Label: "Set", Diff: true},
-			mp.Metrics{Name: "cmd_flush", Label: "Flush", Diff: true},
-			mp.Metrics{Name: "cmd_touch", Label: "Touch", Diff: true},
+			mp.Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "cmd_set", Label: "Set", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "cmd_flush", Label: "Flush", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "cmd_touch", Label: "Touch", Diff: true, Type: "uint64"},
 		},
 	},
 	"memcached.hitmiss": mp.Graphs{
 		Label: "Memcached Hits/Misses",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "get_hits", Label: "Get Hits", Diff: true},
-			mp.Metrics{Name: "get_misses", Label: "Get Misses", Diff: true},
-			mp.Metrics{Name: "delete_hits", Label: "Delete Hits", Diff: true},
-			mp.Metrics{Name: "delete_misses", Label: "Delete Misses", Diff: true},
-			mp.Metrics{Name: "incr_hits", Label: "Incr Hits", Diff: true},
-			mp.Metrics{Name: "incr_misses", Label: "Incr Misses", Diff: true},
-			mp.Metrics{Name: "cas_hits", Label: "Cas Hits", Diff: true},
-			mp.Metrics{Name: "cas_misses", Label: "Cas Misses", Diff: true},
-			mp.Metrics{Name: "touch_hits", Label: "Touch Hits", Diff: true},
-			mp.Metrics{Name: "touch_misses", Label: "Touch Misses", Diff: true},
+			mp.Metrics{Name: "get_hits", Label: "Get Hits", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "get_misses", Label: "Get Misses", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "delete_hits", Label: "Delete Hits", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "delete_misses", Label: "Delete Misses", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "incr_hits", Label: "Incr Hits", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "incr_misses", Label: "Incr Misses", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "cas_hits", Label: "Cas Hits", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "cas_misses", Label: "Cas Misses", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "touch_hits", Label: "Touch Hits", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "touch_misses", Label: "Touch Misses", Diff: true, Type: "uint64"},
 		},
 	},
 	"memcached.evictions": mp.Graphs{
 		Label: "Memcached Evictions",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "evictions", Label: "Evictions", Diff: true},
+			mp.Metrics{Name: "evictions", Label: "Evictions", Diff: true, Type: "uint64"},
 		},
 	},
 	"memcached.unfetched": mp.Graphs{
 		Label: "Memcached Unfetched",
 		Unit:  "integer",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "expired_unfetched", Label: "Expired unfetched", Diff: true},
-			mp.Metrics{Name: "evicted_unfetched", Label: "Evicted unfetched", Diff: true},
+			mp.Metrics{Name: "expired_unfetched", Label: "Expired unfetched", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "evicted_unfetched", Label: "Evicted unfetched", Diff: true, Type: "uint64"},
 		},
 	},
 	"memcached.rusage": mp.Graphs{
@@ -73,8 +74,8 @@ var graphdef map[string](mp.Graphs) = map[string](mp.Graphs){
 		Label: "Memcached Traffics",
 		Unit:  "bytes",
 		Metrics: [](mp.Metrics){
-			mp.Metrics{Name: "bytes_read", Label: "Read", Diff: true},
-			mp.Metrics{Name: "bytes_written", Label: "Write", Diff: true},
+			mp.Metrics{Name: "bytes_read", Label: "Read", Diff: true, Type: "uint64"},
+			mp.Metrics{Name: "bytes_written", Label: "Write", Diff: true, Type: "uint64"},
 		},
 	},
 }
@@ -84,14 +85,14 @@ type MemcachedPlugin struct {
 	Tempfile string
 }
 
-func (m MemcachedPlugin) FetchMetrics() (map[string]float64, error) {
+func (m MemcachedPlugin) FetchMetrics() (map[string]interface{}, error) {
 	conn, err := net.Dial("tcp", m.Target)
 	if err != nil {
 		return nil, err
 	}
 	fmt.Fprintln(conn, "stats")
 	scanner := bufio.NewScanner(conn)
-	stat := make(map[string]float64)
+	stat := make(map[string]interface{})
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -102,7 +103,8 @@ func (m MemcachedPlugin) FetchMetrics() (map[string]float64, error) {
 
 		res := strings.Split(s, " ")
 		if res[0] == "STAT" {
-			stat[res[1]], err = strconv.ParseFloat(res[2], 64)
+			stat[res[1]] = res[2]
+			//strconv.ParseFloat(res[2], 64)
 			if err != nil {
 				log.Println("FetchMetrics:", err)
 			}

--- a/_example/memcached.go
+++ b/_example/memcached.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"log"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -91,6 +91,10 @@ func (m MemcachedPlugin) FetchMetrics() (map[string]interface{}, error) {
 		return nil, err
 	}
 	fmt.Fprintln(conn, "stats")
+	return m.ParseStats(conn)
+}
+
+func (m MemcachedPlugin) ParseStats(conn io.Reader) (map[string]interface{}, error) {
 	scanner := bufio.NewScanner(conn)
 	stat := make(map[string]interface{})
 
@@ -104,10 +108,6 @@ func (m MemcachedPlugin) FetchMetrics() (map[string]interface{}, error) {
 		res := strings.Split(s, " ")
 		if res[0] == "STAT" {
 			stat[res[1]] = res[2]
-			//strconv.ParseFloat(res[2], 64)
-			if err != nil {
-				log.Println("FetchMetrics:", err)
-			}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/_example/memcached_test.go
+++ b/_example/memcached_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphDefinition(t *testing.T) {
+	var memcached MemcachedPlugin
+
+	graphdef := memcached.GraphDefinition()
+	if len(graphdef) != 7 {
+		t.Errorf("GetTempfilename: %d should be 3", len(graphdef))
+	}
+}
+
+func TestParse(t *testing.T) {
+	var memcached MemcachedPlugin
+	stub := `STAT pid 1994
+STAT uptime 92066123
+STAT time 1436890963
+STAT version 1.4.0
+STAT pointer_size 64
+STAT rusage_user 1393.803107
+STAT rusage_system 2947.180187
+STAT curr_connections 1003
+STAT total_connections 965032539
+STAT connection_structures 16388
+STAT cmd_get 4306259844
+STAT cmd_set 2423543841
+STAT cmd_flush 0
+STAT get_hits 2769383483
+STAT get_misses 1536876361
+STAT delete_misses 244469885
+STAT delete_hits 14456835
+STAT incr_misses 0
+STAT incr_hits 0
+STAT decr_misses 0
+STAT decr_hits 0
+STAT cas_misses 0
+STAT cas_hits 0
+STAT cas_badval 0
+STAT bytes_read 8328670869009
+STAT bytes_written 9151962263382
+STAT limit_maxbytes 2147483648
+STAT accepting_conns 1
+STAT listen_disabled_num 0
+STAT threads 5
+STAT conn_yields 1487476
+STAT bytes 621371972
+STAT curr_items 955652
+STAT total_items 2423543841
+STAT evictions 236677775
+END
+`
+
+	memcachedStats := bytes.NewBufferString(stub)
+
+	stat, err := memcached.ParseStats(memcachedStats)
+	fmt.Println(stat)
+	assert.Nil(t, err)
+	// Memcached Stats
+	assert.EqualValues(t, reflect.TypeOf(stat["get_hits"]).String(), "string")
+	assert.EqualValues(t, stat["get_hits"].(string), "2769383483")
+}

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -44,12 +44,16 @@ func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
 }
 
 func (h *MackerelPlugin) printValue(w io.Writer, key string, value interface{}, now time.Time) {
-	if reflect.TypeOf(value).String() == "float64" && (math.IsNaN(value.(float64)) || math.IsInf(value.(float64), 0)) {
+	valueType := reflect.TypeOf(value)
+	if valueType == nil {
+		return
+	}
+	if valueType.String() == "float64" && (math.IsNaN(value.(float64)) || math.IsInf(value.(float64), 0)) {
 		log.Printf("Invalid value: key = %s, value = %f\n", key, value)
 		return
 	}
 
-	switch reflect.TypeOf(value).String() {
+	switch valueType.String() {
 	case "uint32":
 		fmt.Fprintf(w, "%s\t%d\t%d\n", key, value.(uint32), now.Unix())
 	case "uint64":
@@ -158,8 +162,12 @@ func (h *MackerelPlugin) OutputValues() {
 		for _, metric := range graph.Metrics {
 			var value interface{}
 			value = stat[metric.Name]
+			valueType := reflect.TypeOf(value)
+			if valueType == nil {
+				continue
+			}
 
-			switch reflect.TypeOf(value).String() {
+			switch valueType.String() {
 			case "string":
 				switch metric.Type {
 				case "uint64":

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"reflect"
 	"time"
 )
 
@@ -28,7 +29,7 @@ type Graphs struct {
 }
 
 type Plugin interface {
-	FetchMetrics() (map[string]float64, error)
+	FetchMetrics() (map[string]interface{}, error)
 	GraphDefinition() map[string]Graphs
 }
 
@@ -42,20 +43,23 @@ func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
 	return mp
 }
 
-func (h *MackerelPlugin) printValue(w io.Writer, key string, value float64, now time.Time) {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
+func (h *MackerelPlugin) printValue(w io.Writer, key string, value interface{}, now time.Time) {
+	if reflect.TypeOf(value).String() == "float64" && (math.IsNaN(value.(float64)) || math.IsInf(value.(float64), 0)) {
 		log.Printf("Invalid value: key = %s, value = %f\n", key, value)
 		return
 	}
 
-	if value == float64(int(value)) {
-		fmt.Fprintf(w, "%s\t%d\t%d\n", key, int(value), now.Unix())
-	} else {
+	switch reflect.TypeOf(value).String() {
+	case "uint32":
+		fmt.Fprintf(w, "%s\t%d\t%d\n", key, value.(uint32), now.Unix())
+	case "uint64":
+		fmt.Fprintf(w, "%s\t%d\t%d\n", key, value.(uint64), now.Unix())
+	default:
 		fmt.Fprintf(w, "%s\t%f\t%d\n", key, value, now.Unix())
 	}
 }
 
-func (h *MackerelPlugin) fetchLastValues() (map[string]float64, time.Time, error) {
+func (h *MackerelPlugin) fetchLastValues() (map[string]interface{}, time.Time, error) {
 	lastTime := time.Now()
 
 	f, err := os.Open(h.Tempfilename())
@@ -67,17 +71,17 @@ func (h *MackerelPlugin) fetchLastValues() (map[string]float64, time.Time, error
 	}
 	defer f.Close()
 
-	stat := make(map[string]float64)
+	stat := make(map[string]interface{})
 	decoder := json.NewDecoder(f)
 	err = decoder.Decode(&stat)
-	lastTime = time.Unix(int64(stat["_lastTime"]), 0)
+	lastTime = time.Unix(stat["_lastTime"].(int64), 0)
 	if err != nil {
 		return stat, lastTime, err
 	}
 	return stat, lastTime, nil
 }
 
-func (h *MackerelPlugin) saveValues(values map[string]float64, now time.Time) error {
+func (h *MackerelPlugin) saveValues(values map[string]interface{}, now time.Time) error {
 	f, err := os.Create(h.Tempfilename())
 	if err != nil {
 		return err
@@ -94,7 +98,7 @@ func (h *MackerelPlugin) saveValues(values map[string]float64, now time.Time) er
 	return nil
 }
 
-func (h *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float64, lastTime time.Time, valType string) (float64, error) {
+func (h *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float64, lastTime time.Time) (float64, error) {
 	diffTime := now.Unix() - lastTime.Unix()
 	if diffTime > 600 {
 		return 0, errors.New("Too long duration")
@@ -102,15 +106,43 @@ func (h *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float6
 
 	diff := (value - lastValue) * 60 / float64(diffTime)
 
-	// Negative value means counter reset.
-	switch valType {
-	case "uint32":
-		if diff < 0 {
-			diff = diff + math.MaxUint32
-		}
+	return diff, nil
+}
+
+func (h *MackerelPlugin) calcDiffUint32(value uint32, now time.Time, lastValue uint32, lastTime time.Time) (float64, error) {
+	diffTime := now.Unix() - lastTime.Unix()
+	if diffTime > 600 {
+		return 0, errors.New("Too long duration")
 	}
 
-	return diff, nil
+	diff := value - lastValue
+
+	// Negative value means counter reset.
+	if diff < 0 {
+		diff = diff + math.MaxUint32
+	}
+
+	revisedDiff := float64(diff*60) / float64(diffTime)
+
+	return revisedDiff, nil
+}
+
+func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue uint64, lastTime time.Time) (float64, error) {
+	diffTime := now.Unix() - lastTime.Unix()
+	if diffTime > 600 {
+		return 0, errors.New("Too long duration")
+	}
+
+	diff := value - lastValue
+
+	// Negative value means counter reset.
+	if diff < 0 {
+		diff = diff + math.MaxUint64
+	}
+
+	revisedDiff := float64(diff*60) / float64(diffTime)
+
+	return revisedDiff, nil
 }
 
 func (h *MackerelPlugin) Tempfilename() string {
@@ -141,7 +173,14 @@ func (h *MackerelPlugin) OutputValues() {
 			if metric.Diff {
 				_, ok := lastStat[metric.Name]
 				if ok {
-					value, err = h.calcDiff(value, now, lastStat[metric.Name], lastTime, metric.Type)
+					switch metric.Type {
+					case "uint32":
+						value, err = h.calcDiffUint32(value.(uint32), now, lastStat[metric.Name].(uint32), lastTime)
+					case "uint64":
+						value, err = h.calcDiffUint64(value.(uint64), now, lastStat[metric.Name].(uint64), lastTime)
+					default:
+						value, err = h.calcDiff(value.(float64), now, lastStat[metric.Name].(float64), lastTime)
+					}
 					if err != nil {
 						log.Println("OutputValues: ", err)
 					}
@@ -151,17 +190,17 @@ func (h *MackerelPlugin) OutputValues() {
 			}
 
 			if metric.Scale != 0 {
-				value *= metric.Scale
+				switch metric.Type {
+				case "uint32":
+					value = value.(uint32) * uint32(metric.Scale)
+				case "uint64":
+					value = value.(uint64) * uint64(metric.Scale)
+				default:
+					value = value.(float64) * metric.Scale
+				}
 			}
 
-			switch metric.Type {
-			case "uint32", "uint64":
-				if value > 0.0 {
-					h.printValue(os.Stdout, key+"."+metric.Name, value, now)
-				}
-			default:
-				h.printValue(os.Stdout, key+"."+metric.Name, value, now)
-			}
+			h.printValue(os.Stdout, key+"."+metric.Name, value, now)
 		}
 	}
 }

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -12,11 +12,13 @@ import (
 )
 
 type Metrics struct {
-	Name    string  `json:"name"`
-	Label   string  `json:"label"`
-	Diff    bool    `json:"diff"`
-	Stacked bool    `json:"stacked"`
-	Scale   float64 `json:"scale"`
+	Name     string  `json:"name"`
+	Label    string  `json:"label"`
+	Diff     bool    `json:"diff"`
+	Counter  bool    `json:"counter"`
+	Unsigned bool    `json:"unsigned"`
+	Stacked  bool    `json:"stacked"`
+	Scale    float64 `json:"scale"`
 }
 
 type Graphs struct {
@@ -92,13 +94,19 @@ func (h *MackerelPlugin) saveValues(values map[string]float64, now time.Time) er
 	return nil
 }
 
-func (h *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float64, lastTime time.Time) (float64, error) {
+func (h *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float64, lastTime time.Time, counter bool) (float64, error) {
 	diffTime := now.Unix() - lastTime.Unix()
 	if diffTime > 600 {
 		return 0, errors.New("Too long duration")
 	}
 
 	diff := (value - lastValue) * 60 / float64(diffTime)
+
+	// Negative value means counter reset.
+	if counter && diff < 0 {
+		diff = diff + math.MaxUint32
+	}
+
 	return diff, nil
 }
 
@@ -130,7 +138,7 @@ func (h *MackerelPlugin) OutputValues() {
 			if metric.Diff {
 				_, ok := lastStat[metric.Name]
 				if ok {
-					value, err = h.calcDiff(value, now, lastStat[metric.Name], lastTime)
+					value, err = h.calcDiff(value, now, lastStat[metric.Name], lastTime, metric.Counter)
 					if err != nil {
 						log.Println("OutputValues: ", err)
 					}
@@ -143,7 +151,9 @@ func (h *MackerelPlugin) OutputValues() {
 				value *= metric.Scale
 			}
 
-			h.printValue(os.Stdout, key+"."+metric.Name, value, now)
+			if metric.Unsigned == false || value < 0.0 {
+				h.printValue(os.Stdout, key+"."+metric.Name, value, now)
+			}
 		}
 	}
 }

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -14,7 +14,7 @@ func TestCalcDiff(t *testing.T) {
 	now := time.Now()
 	last := time.Unix(now.Unix()-10, 0)
 
-	diff, err := mp.calcDiff(val1, now, val2, last, false)
+	diff, err := mp.calcDiff(val1, now, val2, last, "")
 	if diff != 60 {
 		t.Errorf("calcDiff: %f should be %f", diff, 60.0)
 	}
@@ -31,7 +31,7 @@ func TestCalcDiffWithUInt32OverflowWithSigned(t *testing.T) {
 	lastval := (math.MaxUint32) - 10.0
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiff(val, now, lastval, last, false)
+	diff, err := mp.calcDiff(val, now, lastval, last, "int32")
 	if diff > 0 {
 		t.Errorf("calcDiff: last: %f, now: %f, %f should be negative", val, lastval, diff)
 	}
@@ -48,7 +48,7 @@ func TestCalcDiffWithUInt32Overflow(t *testing.T) {
 	lastval := (math.MaxUint32) - 10.0
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiff(val, now, lastval, last, true)
+	diff, err := mp.calcDiff(val, now, lastval, last, "uint32")
 	if diff != 20 {
 		t.Errorf("calcDiff: last: %f, now: %f, %f should be %f", val, lastval, diff, 20.0)
 	}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -28,15 +28,13 @@ func TestCalcDiffWithUInt32WithReset(t *testing.T) {
 
 	val := uint32(10)
 	now := time.Now()
-	lastval := math.MaxUint32 - uint32(10)
+	lastval := uint32(12345)
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiffUint32(val, now, lastval, last)
-	if diff > 0 {
-		t.Errorf("calcDiff: last: %f, now: %f, %f should be negative", val, lastval, diff)
-	}
+	diff, err := mp.calcDiffUint32(val, now, lastval, last, 10)
 	if err != nil {
-		t.Error("calcDiff causes an error")
+	} else {
+		t.Error("calcDiffUint32 with counter reset should cause an error: %f", diff)
 	}
 }
 
@@ -48,7 +46,7 @@ func TestCalcDiffWithUInt32Overflow(t *testing.T) {
 	lastval := math.MaxUint32 - uint32(10)
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiffUint32(val, now, lastval, last)
+	diff, err := mp.calcDiffUint32(val, now, lastval, last, 10)
 	if diff != 21.0 {
 		t.Errorf("calcDiff: last: %d, now: %d, %f should be %f", val, lastval, diff, 21.0)
 	}
@@ -65,7 +63,7 @@ func TestCalcDiffWithUInt64Overflow(t *testing.T) {
 	lastval := math.MaxUint64 - uint64(10)
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiffUint64(val, now, lastval, last)
+	diff, err := mp.calcDiffUint64(val, now, lastval, last, 10)
 	if diff != 21.0 {
 		t.Errorf("calcDiff: last: %d, now: %d, %f should be %f", val, lastval, diff, 21.0)
 	}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -14,7 +14,7 @@ func TestCalcDiff(t *testing.T) {
 	now := time.Now()
 	last := time.Unix(now.Unix()-10, 0)
 
-	diff, err := mp.calcDiff(val1, now, val2, last, "")
+	diff, err := mp.calcDiff(val1, now, val2, last)
 	if diff != 60 {
 		t.Errorf("calcDiff: %f should be %f", diff, 60.0)
 	}
@@ -31,7 +31,7 @@ func TestCalcDiffWithUInt32OverflowWithSigned(t *testing.T) {
 	lastval := (math.MaxUint32) - 10.0
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiff(val, now, lastval, last, "int32")
+	diff, err := mp.calcDiff(val, now, lastval, last)
 	if diff > 0 {
 		t.Errorf("calcDiff: last: %f, now: %f, %f should be negative", val, lastval, diff)
 	}
@@ -43,14 +43,31 @@ func TestCalcDiffWithUInt32OverflowWithSigned(t *testing.T) {
 func TestCalcDiffWithUInt32Overflow(t *testing.T) {
 	var mp MackerelPlugin
 
-	val := 10.0
+	val := uint32(10)
 	now := time.Now()
-	lastval := (math.MaxUint32) - 10.0
+	lastval := math.MaxUint32 - uint32(10)
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiff(val, now, lastval, last, "uint32")
-	if diff != 20 {
-		t.Errorf("calcDiff: last: %f, now: %f, %f should be %f", val, lastval, diff, 20.0)
+	diff, err := mp.calcDiffUint32(val, now, lastval, last)
+	if diff != 21.0 {
+		t.Errorf("calcDiff: last: %d, now: %d, %f should be %f", val, lastval, diff, 21.0)
+	}
+	if err != nil {
+		t.Error("calcDiff causes an error")
+	}
+}
+
+func TestCalcDiffWithUInt64Overflow(t *testing.T) {
+	var mp MackerelPlugin
+
+	val := uint64(10)
+	now := time.Now()
+	lastval := math.MaxUint64 - uint64(10)
+	last := time.Unix(now.Unix()-60, 0)
+
+	diff, err := mp.calcDiffUint64(val, now, lastval, last)
+	if diff != 21.0 {
+		t.Errorf("calcDiff: last: %d, now: %d, %f should be %f", val, lastval, diff, 21.0)
 	}
 	if err != nil {
 		t.Error("calcDiff causes an error")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -1,6 +1,7 @@
 package mackerelplugin
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -13,9 +14,43 @@ func TestCalcDiff(t *testing.T) {
 	now := time.Now()
 	last := time.Unix(now.Unix()-10, 0)
 
-	diff, err := mp.calcDiff(val1, now, val2, last)
+	diff, err := mp.calcDiff(val1, now, val2, last, false)
 	if diff != 60 {
-		t.Errorf("calcDiff: %f should be %f", diff, 60)
+		t.Errorf("calcDiff: %f should be %f", diff, 60.0)
+	}
+	if err != nil {
+		t.Error("calcDiff causes an error")
+	}
+}
+
+func TestCalcDiffWithUInt32OverflowWithSigned(t *testing.T) {
+	var mp MackerelPlugin
+
+	val := 10.0
+	now := time.Now()
+	lastval := (math.MaxUint32) - 10.0
+	last := time.Unix(now.Unix()-60, 0)
+
+	diff, err := mp.calcDiff(val, now, lastval, last, false)
+	if diff > 0 {
+		t.Errorf("calcDiff: last: %f, now: %f, %f should be negative", val, lastval, diff)
+	}
+	if err != nil {
+		t.Error("calcDiff causes an error")
+	}
+}
+
+func TestCalcDiffWithUInt32Overflow(t *testing.T) {
+	var mp MackerelPlugin
+
+	val := 10.0
+	now := time.Now()
+	lastval := (math.MaxUint32) - 10.0
+	last := time.Unix(now.Unix()-60, 0)
+
+	diff, err := mp.calcDiff(val, now, lastval, last, true)
+	if diff != 20 {
+		t.Errorf("calcDiff: last: %f, now: %f, %f should be %f", val, lastval, diff, 20.0)
 	}
 	if err != nil {
 		t.Error("calcDiff causes an error")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -23,15 +23,15 @@ func TestCalcDiff(t *testing.T) {
 	}
 }
 
-func TestCalcDiffWithUInt32OverflowWithSigned(t *testing.T) {
+func TestCalcDiffWithUInt32WithReset(t *testing.T) {
 	var mp MackerelPlugin
 
-	val := 10.0
+	val := uint32(10)
 	now := time.Now()
-	lastval := (math.MaxUint32) - 10.0
+	lastval := math.MaxUint32 - uint32(10)
 	last := time.Unix(now.Unix()-60, 0)
 
-	diff, err := mp.calcDiff(val, now, lastval, last)
+	diff, err := mp.calcDiffUint32(val, now, lastval, last)
 	if diff > 0 {
 		t.Errorf("calcDiff: last: %f, now: %f, %f should be negative", val, lastval, diff)
 	}


### PR DESCRIPTION
There is many metrics which behave as counter, but current diff calculation does not consider counter reset and overflow.

This pull request make the helper can deal with counter overflow and reset.

Note: the helper use float64 as value type, so it cannot deal with uint64 counter well. this must be another issue.
