### PR TITLE
backport features from go-mackerel-plugin-helper 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
 
 go:
-  - 1.3
+  - tip
+  - 1.7

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+deps:
+	go get -d -v -t .
+	go get github.com/golang/lint/golint
+
+lint: deps
+	go tool vet -all .
+	golint -set_exit_status .
+
+test:
+	go test -v
+
+.PHONY: deps lint test

--- a/_example/memcached.go
+++ b/_example/memcached.go
@@ -4,26 +4,26 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	mp "github.com/mackerelio/go-mackerel-plugin"
 	"log"
 	"net"
-	"os"
 	"strconv"
 	"strings"
+
+	"github.com/mackerelio/go-mackerel-plugin"
 )
 
-var graphdef map[string]mp.Graphs = map[string]mp.Graphs{
+var graphdef map[string]mackerelplugin.Graphs = map[string]mackerelplugin.Graphs{
 	"memcached.connections": {
 		Label: "Memcached Connections",
 		Unit:  "integer",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "curr_connections", Label: "Connections", Diff: false},
 		},
 	},
 	"memcached.cmd": {
 		Label: "Memcached Command",
 		Unit:  "integer",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "cmd_get", Label: "Get", Diff: true},
 			{Name: "cmd_set", Label: "Set", Diff: true},
 			{Name: "cmd_flush", Label: "Flush", Diff: true},
@@ -33,7 +33,7 @@ var graphdef map[string]mp.Graphs = map[string]mp.Graphs{
 	"memcached.hitmiss": {
 		Label: "Memcached Hits/Misses",
 		Unit:  "integer",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "get_hits", Label: "Get Hits", Diff: true},
 			{Name: "get_misses", Label: "Get Misses", Diff: true},
 			{Name: "delete_hits", Label: "Delete Hits", Diff: true},
@@ -49,14 +49,14 @@ var graphdef map[string]mp.Graphs = map[string]mp.Graphs{
 	"memcached.evictions": {
 		Label: "Memcached Evictions",
 		Unit:  "integer",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "evictions", Label: "Evictions", Diff: true},
 		},
 	},
 	"memcached.unfetched": {
 		Label: "Memcached Unfetched",
 		Unit:  "integer",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "expired_unfetched", Label: "Expired unfetched", Diff: true},
 			{Name: "evicted_unfetched", Label: "Evicted unfetched", Diff: true},
 		},
@@ -64,7 +64,7 @@ var graphdef map[string]mp.Graphs = map[string]mp.Graphs{
 	"memcached.rusage": {
 		Label: "Memcached Resouce Usage",
 		Unit:  "float",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "rusage_user", Label: "User", Diff: true},
 			{Name: "rusage_system", Label: "System", Diff: true},
 		},
@@ -72,7 +72,7 @@ var graphdef map[string]mp.Graphs = map[string]mp.Graphs{
 	"memcached.bytes": {
 		Label: "Memcached Traffics",
 		Unit:  "bytes",
-		Metrics: []mp.Metrics{
+		Metrics: []mackerelplugin.Metrics{
 			{Name: "bytes_read", Label: "Read", Diff: true},
 			{Name: "bytes_written", Label: "Write", Diff: true},
 		},
@@ -114,7 +114,7 @@ func (m MemcachedPlugin) FetchMetrics() (map[string]float64, error) {
 	return nil, nil
 }
 
-func (m MemcachedPlugin) GraphDefinition() map[string]mp.Graphs {
+func (m MemcachedPlugin) GraphDefinition() map[string]mackerelplugin.Graphs {
 	return graphdef
 }
 
@@ -127,17 +127,7 @@ func main() {
 	var memcached MemcachedPlugin
 
 	memcached.Target = fmt.Sprintf("%s:%s", *optHost, *optPort)
-	helper := mp.NewMackerelPlugin(memcached)
-
-	if *optTempfile != "" {
-		helper.Tempfile = *optTempfile
-	} else {
-		helper.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-memcached-%s-%s", *optHost, *optPort)
-	}
-
-	if os.Getenv("MACKEREL_AGENT_PLUGIN_META") != "" {
-		helper.OutputDefinitions()
-	} else {
-		helper.OutputValues()
-	}
+	helper := mackerelplugin.NewMackerelPlugin(memcached)
+	helper.Tempfile = *optTempfile
+	helper.Run()
 }

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -50,8 +50,8 @@ type MackerelPlugin struct {
 }
 
 // NewMackerelPlugin returns new MackrelPlugin
-func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
-	return MackerelPlugin{Plugin: plugin}
+func NewMackerelPlugin(plugin Plugin) *MackerelPlugin {
+	return &MackerelPlugin{Plugin: plugin}
 }
 
 func (mp *MackerelPlugin) getWriter() io.Writer {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -2,7 +2,6 @@ package mackerelplugin
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -137,10 +136,13 @@ func (mp *MackerelPlugin) saveValues(values map[string]float64, now time.Time) e
 func (mp *MackerelPlugin) calcDiff(value float64, now time.Time, lastValue float64, lastTime time.Time) (float64, error) {
 	diffTime := now.Unix() - lastTime.Unix()
 	if diffTime > 600 {
-		return 0, errors.New("Too long duration")
+		return 0, fmt.Errorf("Too long duration")
 	}
 
 	diff := (value - lastValue) * 60 / float64(diffTime)
+	if diff < 0 {
+		return 0, fmt.Errorf("Counter seems to be reset.")
+	}
 	return diff, nil
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -1,12 +1,13 @@
 package mackerelplugin
 
 import (
+	"bytes"
 	"testing"
 	"time"
 )
 
 func TestCalcDiff(t *testing.T) {
-	var mp MackerelPlugin
+	var mp *MackerelPlugin
 
 	val1 := 10.0
 	val2 := 0.0
@@ -19,5 +20,38 @@ func TestCalcDiff(t *testing.T) {
 	}
 	if err != nil {
 		t.Error("calcDiff causes an error")
+	}
+}
+
+func TestCalcDiffWithReset(t *testing.T) {
+	var mp *MackerelPlugin
+
+	val := 10.0
+	lastval := 12345.0
+	now := time.Now()
+	last := time.Unix(now.Unix()-60, 0)
+
+	diff, err := mp.calcDiff(val, now, lastval, last)
+	if err == nil {
+		t.Errorf("calcDiff with counter reset should cause an error: %f", diff)
+	}
+}
+
+func TestFormatValues(t *testing.T) {
+	wtr := &bytes.Buffer{}
+	mp := &MackerelPlugin{writer: wtr}
+
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true}
+	stat := map[string]float64{"cmd_get": 1000.0}
+	lastStat := map[string]float64{"cmd_get": 500.0, ".last_diff.cmd_get": 300.0}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(time.Second * (-60))
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+
+	got := wtr.String()
+	expect := "foo.cmd_get	500	1437227240\n"
+	if got != expect {
+		t.Errorf("result of formatValues is not expected one: %s", got)
 	}
 }

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -69,14 +69,17 @@ func (m testMemcachedPlugin) GraphDefinition() map[string]Graphs {
 			Label: "Memcached Command",
 			Unit:  "integer",
 			Metrics: []Metrics{
-				{Name: "cmd_get", Label: "Get", Diff: true},
+				{Name: "cmd_get", Label: "Get"},
 			},
 		},
 	}
 }
 
 func (m testMemcachedPlugin) FetchMetrics() (map[string]float64, error) {
-	return make(map[string]float64), nil
+	return map[string]float64{
+		"cmd_get": 11.0,
+		"cmd_set": 8.0,
+	}, nil
 }
 
 func TestOutputDefinitions(t *testing.T) {
@@ -91,7 +94,21 @@ func TestOutputDefinitions(t *testing.T) {
 `
 	got := wtr.String()
 	if got != expect {
-		t.Errorf("result of output values is invalid :%s", got)
+		t.Errorf("result of OutputDefinitions is invalid :%s", got)
+	}
+}
+
+func TestOutputValues(t *testing.T) {
+	var m testMemcachedPlugin
+	mp := NewMackerelPlugin(m)
+	wtr := &bytes.Buffer{}
+	mp.writer = wtr
+	mp.OutputValues()
+	epoch := time.Now().Unix()
+	expect := fmt.Sprintf("memcached.cmd.cmd_get\t%d\t%d\n", 11, epoch)
+	got := wtr.String()
+	if got != expect {
+		t.Errorf("result of OutputValues is invalid :%s", got)
 	}
 }
 
@@ -185,5 +202,18 @@ func TestPluginOutputDefinitionsWithPrefix(t *testing.T) {
 	got := wtr.String()
 	if got != expect {
 		t.Errorf("result of OutputDefinitions is invalid: %s", got)
+	}
+}
+
+func TestOutputValuesWithPrefix(t *testing.T) {
+	mp := NewMackerelPlugin(testP{})
+	wtr := &bytes.Buffer{}
+	mp.writer = wtr
+	mp.OutputValues()
+	epoch := time.Now().Unix()
+	expect := fmt.Sprintf("testP.bar\t15\t%[1]d\ntestP.fuga.baz\t18\t%[1]d\n", epoch)
+	got := wtr.String()
+	if got != expect {
+		t.Errorf("result of OutputValues is invalid :%s", got)
 	}
 }

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -217,3 +217,47 @@ func TestOutputValuesWithPrefix(t *testing.T) {
 		t.Errorf("result of OutputValues is invalid :%s", got)
 	}
 }
+
+type testPHasDiff struct{}
+
+func (t testPHasDiff) FetchMetrics() (map[string]float64, error) {
+	return nil, nil
+}
+
+func (t testPHasDiff) GraphDefinition() map[string]Graphs {
+	return map[string]Graphs{
+		"hoge": {
+			Metrics: []Metrics{
+				{Name: "hoge1", Label: "hoge1", Diff: true},
+			},
+		},
+	}
+}
+
+type testPHasntDiff struct{}
+
+func (t testPHasntDiff) FetchMetrics() (map[string]float64, error) {
+	return nil, nil
+}
+
+func (t testPHasntDiff) GraphDefinition() map[string]Graphs {
+	return map[string]Graphs{
+		"hoge": {
+			Metrics: []Metrics{
+				{Name: "hoge1", Label: "hoge1"},
+			},
+		},
+	}
+}
+
+func TestPluginHasDiff(t *testing.T) {
+	pHasDiff := NewMackerelPlugin(testPHasDiff{})
+	if !pHasDiff.hasDiff() {
+		t.Errorf("something went wrong")
+	}
+
+	pHasntDiff := NewMackerelPlugin(testPHasntDiff{})
+	if pHasntDiff.hasDiff() {
+		t.Errorf("something went wrong")
+	}
+}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -14,8 +14,8 @@ func TestCalcDiff(t *testing.T) {
 	last := time.Unix(now.Unix()-10, 0)
 
 	diff, err := mp.calcDiff(val1, now, val2, last)
-	if diff != 60 {
-		t.Errorf("calcDiff: %f should be %f", diff, 60)
+	if diff != 60.0 {
+		t.Errorf("calcDiff: %f should be %f", diff, 60.0)
 	}
 	if err != nil {
 		t.Error("calcDiff causes an error")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -59,6 +59,42 @@ func TestFormatValues(t *testing.T) {
 	}
 }
 
+// an example implementation
+type testMemcachedPlugin struct {
+}
+
+func (m testMemcachedPlugin) GraphDefinition() map[string]Graphs {
+	return map[string]Graphs{
+		"memcached.cmd": {
+			Label: "Memcached Command",
+			Unit:  "integer",
+			Metrics: []Metrics{
+				{Name: "cmd_get", Label: "Get", Diff: true},
+			},
+		},
+	}
+}
+
+func (m testMemcachedPlugin) FetchMetrics() (map[string]float64, error) {
+	return make(map[string]float64), nil
+}
+
+func TestOutputDefinitions(t *testing.T) {
+	var m testMemcachedPlugin
+	mp := NewMackerelPlugin(m)
+	wtr := &bytes.Buffer{}
+	mp.writer = wtr
+	mp.OutputDefinitions()
+
+	expect := `# mackerel-agent-plugin
+{"graphs":{"memcached.cmd":{"label":"Memcached Command","unit":"integer","metrics":[{"name":"cmd_get","label":"Get","stacked":false}]}}}
+`
+	got := wtr.String()
+	if got != expect {
+		t.Errorf("result of output values is invalid :%s", got)
+	}
+}
+
 type testP struct{}
 
 func (t testP) FetchMetrics() (map[string]float64, error) {


### PR DESCRIPTION
- Generate default tempfile filename using os.Args[0]
  - https://github.com/mackerelio/go-mackerel-plugin-helper/pull/22
- support `$MACKEREL_PLUGIN_WORKDIR`
  - https://github.com/mackerelio/go-mackerel-plugin-helper/pull/21
- remove metrics.(type/scale) keys from json. these are not used in server side
  - https://github.com/mackerelio/go-mackerel-plugin-helper/pull/16
- support `PluginWithPrefix` interface
  - https://github.com/mackerelio/go-mackerel-plugin-helper/pull/15
- define `mp.Run()`
  - https://github.com/mackerelio/go-mackerel-plugin-helper/pull/9
- don't generate tempfile when the plugin has no diff metrics