### PR TITLE
Upgrade Go version to 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 
 go:
-  - tip
-  - 1.7
+  - 1.9.x


### PR DESCRIPTION
This pull request upgrades the version of Go on TravisCI.