### PR TITLE
upgrade Go toolchain: 1.9 -> 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x


### PR DESCRIPTION
fix CVE-2019-6486

golang/go#29903