### PR TITLE
avoid to store invalid numbers in the plugin state

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -147,7 +147,7 @@ func (mp *MackerelPlugin) saveValues(values map[string]float64, now time.Time) e
 	defer f.Close()
 
 	// Since Go 1.15 strconv.ParseFloat returns +Inf if it couldn't parse a string.
-	// But JSON is not accept invalid numbers, such as +Inf, -Inf or NaN.
+	// But JSON does not accept invalid numbers, such as +Inf, -Inf or NaN.
 	// We perhaps have some plugins that is affected above change,
 	// so saveState should clear invalid numbers in the values before saving it.
 	for k, v := range values {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -146,6 +146,16 @@ func (mp *MackerelPlugin) saveValues(values map[string]float64, now time.Time) e
 	}
 	defer f.Close()
 
+	// Since Go 1.15 strconv.ParseFloat returns +Inf if it couldn't parse a string.
+	// But JSON is not accept invalid numbers, such as +Inf, -Inf or NaN.
+	// We perhaps have some plugins that is affected above change,
+	// so saveState should clear invalid numbers in the values before saving it.
+	for k, v := range values {
+		if math.IsInf(v, 0) || math.IsNaN(v) {
+			delete(values, k)
+		}
+	}
+
 	values["_lastTime"] = float64(now.Unix())
 	encoder := json.NewEncoder(f)
 	err = encoder.Encode(values)


### PR DESCRIPTION
I fixed two plugins, but we perhaps have some plugins that try to save invalid numbers to the plugin state.

see mackerelio/mackerel-agent-plugins#770 and mackerelio/mackerel-agent-plugins#779