### PR TITLE
add s, ms, bps to metric units

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A plugin can specify `Graphs` and `Metrics`.
 - `Unit`: Unit for lines, `float`, `integer`, `percentage`, `seconds`, `milliseconds`, `bytes`, `bytes/sec`, `bits/sec`, `iops` can be specified.
 - `Metrics`: Array of `Metrics` which represents each line.
 
-`Metics` includes followings:
+`Metrics` includes followings:
 
 - `Name`: Key of the line
 - `Label`: Label of the line

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A plugin can specify `Graphs` and `Metrics`.
 `Graphs` includes followings:
 
 - `Label`: Label for the graph
-- `Unit`: Unit for lines, `float`, `integer`, `percentage`, `bytes`, `bytes/sec`, `iops` can be specified.
+- `Unit`: Unit for lines, `float`, `integer`, `percentage`, `seconds`, `milliseconds`, `bytes`, `bytes/sec`, `bits/sec`, `iops` can be specified.
 - `Metrics`: Array of `Metrics` which represents each line.
 
 `Metics` includes followings:

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -22,8 +22,11 @@ const (
 	UnitFloat          = "float"
 	UnitInteger        = "integer"
 	UnitPercentage     = "percentage"
+	UnitSeconds        = "seconds"
+	UnitMilliseconds   = "milliseconds"
 	UnitBytes          = "bytes"
 	UnitBytesPerSecond = "bytes/sec"
+	UnitBitsPerSecond  = "bits/sec"
 	UnitIOPS           = "iops"
 )
 


### PR DESCRIPTION
The following metric units are now available:

- seconds [s]
- milliseconds [ms]
- bits/sec [bps]

In addition, I found a typo in the README and fixed it.