### PR TITLE
update go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-profile: profile.cov
           parallel: true
-          job-number: ${{ strategy.job-index }}
+          flag-name: Go-${{ matrix.go }}
   finish:
     needs: [lint, test]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
-          version: v1.43
+          go-version: 1.18
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.46
   test:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,46 +3,46 @@ name: Build
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.43
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.43
   test:
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macOS-11', 'windows-2019']
-        go: ['1.17.x', '1.16.x']
+        os: ["ubuntu-20.04", "macOS-11", "windows-2019"]
+        go: ["1.18.x", "1.17.x"]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
-    - run: go test -race -covermode=atomic -coverprofile=profile.cov
-      shell: bash
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-profile: profile.cov
-        parallel: true
-        job-number: ${{ strategy.job-index }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go test -race -covermode=atomic -coverprofile=profile.cov
+        shell: bash
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-profile: profile.cov
+          parallel: true
+          job-number: ${{ strategy.job-index }}
   finish:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-    - uses: shogo82148/actions-goveralls@v1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - uses: shogo82148/actions-goveralls@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/mackerelio/go-mackerel-plugin
 
 go 1.18
 
-require github.com/mackerelio/golib v1.2.1
+require (
+	github.com/mackerelio/golib v1.2.1
+	golang.org/x/text v0.3.7
+)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mackerelio/go-mackerel-plugin
 
-go 1.16
+go 1.18
 
 require github.com/mackerelio/golib v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg4=
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -14,6 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/mackerelio/golib/pluginutil"
 )
 
@@ -305,7 +308,7 @@ type GraphDef struct {
 
 func title(s string) string {
 	r := strings.NewReplacer(".", " ", "_", " ", "*", "", "#", "")
-	return strings.TrimSpace(strings.Title(r.Replace(s)))
+	return strings.TrimSpace(cases.Title(language.Und, cases.NoLower).String(r.Replace(s)))
 }
 
 // OutputDefinitions outputs graph definitions


### PR DESCRIPTION
- updated Go to version 1.18
- updated some actions
- replaced the deprecated function `string.Title(str)`