### PR TITLE
pinned workflows@v1.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,6 @@ on:
   pull_request:
 jobs:
   lint:
-    uses: mackerelio/workflows/.github/workflows/go-lint.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.0.2
   test:
-    uses: mackerelio/workflows/.github/workflows/go-test.yml@main
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.0.2


### PR DESCRIPTION
I pinned workflows version, and setup Dependabot to check whether newer-version is available.
Its version is based on Go 1.20 and 1.21 by default.