### PR TITLE
upgrade workflows: 1.1.0 -> 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,6 @@ on:
   pull_request:
 jobs:
   lint:
-    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.1.0
+    uses: mackerelio/workflows/.github/workflows/go-lint.yml@v1.4.0
   test:
-    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.1.0
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@v1.4.0


### PR DESCRIPTION
Dependabot has been stopped so I manually upgrade our reusable workflow.